### PR TITLE
Try matching on a Pattern type

### DIFF
--- a/manifests/profile/test.pp
+++ b/manifests/profile/test.pp
@@ -5,9 +5,13 @@
 # @example
 #   include regex_variable::profile::test
 class regex_variable::profile::test (
-  Variant[Pattern[$regex_variable::params::postgresql_setting_numeric_w_memory_unit_regex],
+  Variant[Regex_variable::Test,
     Pattern[/\A\d+\Z/],
     Integer[64]]  $work_mem = '4MB'
 ) inherits regex_variable {
   notify { "work_mem is ${work_mem}" : }
+
+  if $work_mem.match(Regex_variable::Test) {
+    notify { $1 : }
+  }
 }

--- a/spec/classes/profile/test_spec.rb
+++ b/spec/classes/profile/test_spec.rb
@@ -1,11 +1,6 @@
 require 'spec_helper'
 
 describe 'regex_variable::profile::test' do
-  let(:pre_condition) {
-      <<-PRE_COND
-        class {'regex_variable': }
-      PRE_COND
-      }
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }

--- a/types/test.pp
+++ b/types/test.pp
@@ -1,0 +1,1 @@
+type Regex_variable::Test = Pattern[/\A(\d+)(\s*)(kB|MB|GB|TB)\Z/]


### PR DESCRIPTION
Trying this out I get 

```
failed: rspec: ./spec/classes/profile/test_spec.rb:8: error during compilation: Evaluation Error: Error while evaluating a Method call, match() expects pattern of T, where T is String, Regexp, Regexp[r], Pattern[p], or Array[T]. Got Puppet::Pops::Types::PTypeAliasType (file: /Users/nw/git_repos/regex_variable/spec/fixtures/modules/regex_variable/manifests/profile/test.pp, line: 14, column: 21) on node noway.local
  regex_variable::profile::test on redhat-7-x86_64 should compile into a catalogue without dependency cycles
```